### PR TITLE
added regression test for maxcolwidths doesn't accept tuple issue

### DIFF
--- a/test/test_regression.py
+++ b/test/test_regression.py
@@ -488,6 +488,27 @@ def test_preserve_line_breaks_with_maxcolwidths():
     assert_equal(expected, result)
 
 
+def test_maxcolwidths_accepts_list_or_tuple():
+    "Regression: maxcolwidths can accept a list or a tuple (github issue #214)"
+    table = [["lorem ipsum dolor sit amet"]*3]
+    expected = "\n".join(
+        [
+            "+-------------+----------+----------------------------+",
+            "| lorem ipsum | lorem    | lorem ipsum dolor sit amet |",
+            "| dolor sit   | ipsum    |                            |",
+            "| amet        | dolor    |                            |",
+            "|             | sit amet |                            |",
+            "+-------------+----------+----------------------------+",
+        ]
+    )
+    # test with maxcolwidths as a list
+    result = tabulate(table, tablefmt="grid", maxcolwidths=[12, 8])
+    assert_equal(expected, result)
+    # test with maxcolwidths as a tuple
+    result = tabulate(table, tablefmt="grid", maxcolwidths=(12, 8))
+    assert_equal(expected, result)
+
+
 def test_exception_on_empty_data_with_maxcolwidths():
     "Regression: exception on empty data when using maxcolwidths (github issue #180)"
     result = tabulate([], maxcolwidths=5)


### PR DESCRIPTION
hello @Racerroar888 ,  

I added a regression test for the "maxcolwidths doesn't accept tuple" issue #214

in file `test/test_regression.py` the function is `test_maxcolwidths_accepts_list_or_tuple` 

I've never done a PR to a PR before, but you can just copy the code into your PR if it won't merge.