### PR TITLE
fix merge conflict in README.md file

### DIFF
--- a/README.md
+++ b/README.md
@@ -1123,5 +1123,5 @@ Bart Broere, Vilhelm Prytz, Alexander Gažo, Hugo van Kemenade,
 jamescooke, Matt Warner, Jérôme Provensal, Kevin Deldycke,
 Kian-Meng Ang, Kevin Patterson, Shodhan Save, cleoold, KOLANICH,
 Vijaya Krishna Kasula, Furcy Pin, Christian Fibich, Shaun Duncan,
-Dimitri Papadopoulos, Racerroar.
+Dimitri Papadopoulos, Élie Goudout, Racerroar, Phill Zarfos.
 


### PR DESCRIPTION
- Github is reporting a conflict in the original PR that is preventing the PR merge.
- This commit fixes the last line of the README.md file, which I believe is the cause of the conflict.  
- I also added myself as a contributor. ;)

@Racerroar888 if you merge this PR into your repo, that should fix the conflict message you are seeing at the bottom of your original PR.  After this merge, they should be able to merge your PR back to the master astanin repo.